### PR TITLE
BugFix1 button highlights, clicking it will cause the next deployed s…

### DIFF
--- a/C#/src/DeploymentController.cs
+++ b/C#/src/DeploymentController.cs
@@ -75,7 +75,7 @@ static class DeploymentController
 			if (GameController.HumanPlayer.ReadyToDeploy & UtilityFunctions.IsMouseInRectangle(PLAY_BUTTON_LEFT, TOP_BUTTONS_TOP, PLAY_BUTTON_WIDTH, TOP_BUTTONS_HEIGHT)) {
 				GameController.EndDeployment();
 			} else if (UtilityFunctions.IsMouseInRectangle(UP_DOWN_BUTTON_LEFT, TOP_BUTTONS_TOP, DIR_BUTTONS_WIDTH, TOP_BUTTONS_HEIGHT)) {
-				_currentDirection = Direction.LeftRight;
+				_currentDirection = Direction.UpDown; // SV - changed from Direction.LeftRight for bug fix #1
 			} else if (UtilityFunctions.IsMouseInRectangle(LEFT_RIGHT_BUTTON_LEFT, TOP_BUTTONS_TOP, DIR_BUTTONS_WIDTH, TOP_BUTTONS_HEIGHT)) {
 				_currentDirection = Direction.LeftRight;
 			} else if (UtilityFunctions.IsMouseInRectangle(RANDOM_BUTTON_LEFT, TOP_BUTTONS_TOP, RANDOM_BUTTON_WIDTH, TOP_BUTTONS_HEIGHT)) {


### PR DESCRIPTION
Fix for Bug #1
Fix affects DeploymentController.cs
Clicking either button will cause the next deployed ship to be in the same orientation as the arrow.
Unsure if more functionality was required from the button, but it now highlights correctly and reflects the functionality of the other, previously implemented button.